### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/leisurelicht/norm/security/code-scanning/3](https://github.com/leisurelicht/norm/security/code-scanning/3)

To fix the problem, add a `permissions` key to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs tests, it only needs `contents: read` permission. The best way to do this is to add the following block at the top level of the workflow (after the `name:` and before `on:`), so it applies to all jobs in the workflow. No changes to the jobs or steps are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
